### PR TITLE
Add guard to prevent partial script from being run

### DIFF
--- a/src/distrib/make_installer.sh
+++ b/src/distrib/make_installer.sh
@@ -6,6 +6,13 @@ set -xeuo pipefail
 
 cat <<EOF
 #/usr/bin/env bash
+
+# We wrap the entire script in a big function which we only call at the very end, in order to
+# protect against the possibility of the connection dying mid-script. This protects us against
+# the problem described in this blog post:
+#   https://archive.ph/xvQVA
+_() {
+
 set -xeuo pipefail
 
 PREFIX=\${PREFIX:-/usr/local}
@@ -84,4 +91,9 @@ install -m755 bin/* "\$PREFIX/bin"
 if ! [[ -e \$PREFIX/bin/opam ]]; then
   install_opam
 fi
+
+}
+
+# Now that we know the whole script has downloaded, run it.
+_ "$0" "$@"
 EOF

--- a/src/distrib/make_installer.sh
+++ b/src/distrib/make_installer.sh
@@ -6,14 +6,13 @@ set -xeuo pipefail
 
 cat <<EOF
 #/usr/bin/env bash
+set -xeuo pipefail
 
 # We wrap the entire script in a big function which we only call at the very end, in order to
 # protect against the possibility of the connection dying mid-script. This protects us against
 # the problem described in this blog post:
 #   https://archive.ph/xvQVA
 _() {
-
-set -xeuo pipefail
 
 PREFIX=\${PREFIX:-/usr/local}
 

--- a/src/distrib/make_installer.sh
+++ b/src/distrib/make_installer.sh
@@ -95,5 +95,5 @@ fi
 }
 
 # Now that we know the whole script has downloaded, run it.
-_ "$0" "$@"
+_ "\$0" "\$@"
 EOF


### PR DESCRIPTION
It adds the same guard as the sandstorm installer but links to an archived copy of the blog post.

Closes #47