### PR TITLE
Add a `DETAILS` section to the man page

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ When prompted to install the platform tools, for a given switch, `ocaml-platform
 - If needed, it creates the sandbox switch, to builds the tools it needs to build, and add to the local repository the new packages.
 - Finally, it installs all tools from the local binary repository.
 
-Note that this mechanism makes `opam` fully aware of `ocaml-platform's installed package.
+Note that this mechanism makes `opam` fully aware of `ocaml-platform`'s installed package.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ git clone git@github.com:tarides/ocaml-platform.git
 
 To run the test, see the [README](https://github.com/tarides/ocaml-platform/blob/main/test/README.md).
 
-## What’s under the hood
+## What's under the hood
 
-Another disclaimer: the current implementation is a WIP, so what’s under the hood may (or may not) change in the future.
+Another disclaimer: the current implementation is a WIP, so what's under the hood may (or may not) change in the future.
 
 Under the hood, `ocaml-platform` uses several mechanisms to install and cache the platform tools.
 
@@ -67,7 +67,7 @@ The libraries are left out to get rid of transitive dependencies, which would de
 
 As setting up a switch and building all platform tools there is costly in time, they are cached in a local opam repository. This also allows to install the platform tools purely through `opam`.
 
-The packages in this repository consists of pre-compiled packages with no libraries, so they don’t have to be built and their installation consists only of copying files.
+The packages in this repository consists of pre-compiled packages with no libraries, so they don't have to be built and their installation consists only of copying files.
 
 When the original package contains libraries, it differs from the binary package. In this case, the name of the binary package is suffixed with `+bin+platform`, and installing the original package (eg to have the library) will replace the platform one. In any case, the version of a package in the local repository contains both the original version and the ocaml version they were compiled with, as this may be important for some tools.
 
@@ -81,7 +81,7 @@ When prompted to install the platform tools, for a given switch, `ocaml-platform
 - If needed, it creates the sandbox switch, to builds the tools it needs to build, and add to the local repository the new packages.
 - Finally, it installs all tools from the local binary repository.
 
-Note that this mechanism makes `opam` fully aware of `ocaml-platform`’s installed package.
+Note that this mechanism makes `opam` fully aware of `ocaml-platform's installed package.
 
 ## Roadmap
 

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -88,51 +88,39 @@ let main () =
         `S Manpage.s_commands;
         `S Manpage.s_bugs;
         `P "Report them, see $(i,%%PKG_HOMEPAGE%%) for contact information.";
-        `S "NOTES";
+        `S "DETAILS";
         `P
           "Under the hood, $(mname) uses several mechanisms to install and \
            cache the platform tools.";
         `I
           ( "The sandbox switch",
             "The sandbox switch is a switch in which the tools will be \
-             compiled. The idea of having a separate switch is that the \
-             dependencies of the development tools should not interfere with \
-             the dependencies of your project. The platform tools are normally \
-             installed into the sandbox switch. Then, the installed files, \
-             except for the libraries, are grouped into new opam packages in \
-             the local binary repository (see below). The libraries are left \
-             out to get rid of transitive dependencies, which would defeat the \
-             goal of not interfering with the dependencies of the project." );
+             compiled. The platform tools are normally installed into the \
+             sandbox switch. Then, the installed files, except for the \
+             libraries, are grouped into new opam packages in the local binary \
+             repository (see below)." );
         `I
           ( "The local binary opam repository",
-            "As setting up a switch and building all platform tools there is \
-             costly in time, they are cached in a local opam repository. This \
-             also allows to install the platform tools purely through \
-             $(b,opam). The packages in this repository consists of \
-             pre-compiled packages with no libraries, so they don't have to be \
-             built and their installation consists only of copying files. When \
-             the original package contains libraries, it differs from the \
-             binary package. In this case, the name of the binary package is \
-             suffixed with $(b,+bin+platform), and installing the original \
-             package (eg to have the library) will replace the platform one. \
-             In any case, the version of a package in the local repository \
-             contains both the original version and the ocaml version they \
-             were compiled with, as this may be important for some tools. Note \
-             that the repository is enabled by $(mname) only when it is \
-             needed, and disabled afterward, so using $(mname) should not \
-             alter the behaviour of $(b,opam)." );
+            "All built tools are cached in a local opam repository. The \
+             packages in this repository consists of pre-compiled packages \
+             with no libraries. When the original package contains libraries, \
+             it differs from the binary package. In this case, the name of the \
+             binary package is suffixed with $(b,+bin+platform), and \
+             installing the original package (for instance to have the \
+             library) will replace the platform one. In any case, the version \
+             of a package in the local repository contains both the original \
+             version and the ocaml version they were compiled with, as this \
+             may be important for some tools." );
         `I
-          ( "The pipeline",
+          ( "The overall logic",
             "When prompted to install the platform tools, for a given switch, \
-             $(mname) does the following: - First, it finds for each tool the \
-             latest version compatible with the $(b,ocaml) version of the \
-             switch - Then, it checks which tools have their version already \
-             available in the local binary repo, and which tools need to be \
-             built, - If needed, it creates the sandbox switch, to builds the \
-             tools it needs to build, and add to the local repository the new \
-             packages. - Finally, it installs all tools from the local binary \
-             repository. Note that this mechanism makes $(b,opam) fully aware \
-             of $(mname)'s installed package." );
+             $(mname) first finds for each tool the latest version compatible \
+             with the $(b,ocaml) version of the switch. Then, it checks in the \
+             local binary repo which tools have their version already \
+             available, and which tools need to be built. Only if needed, it \
+             creates the sandbox switch, to builds the missing tools, and adds \
+             corresponding packages to the local repository. Finally, it \
+             installs all tools from the local binary repository." );
         `S Manpage.s_authors;
         `P "Jules Aguillon, $(i,https://github.com/Julow)";
         `P "Paul-Elliot Anglès d'Auriac, $(i,https://github.com/panglesd)";

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -126,6 +126,11 @@ let main () =
         `P "Paul-Elliot Anglès d'Auriac, $(i,https://github.com/panglesd)";
         `P "Sonja Heinze, $(i,https://github.com/pitag-ha)";
         `P "Thibaut Mattio, $(i,https://github.com/tmattio)";
+        `S Manpage.s_see_also;
+        `P
+          "Consult the project repository on \
+           $(i,https://github.com/tarides/ocaml-platform) for more information \
+           on the tool and the Platform.";
       ]
     in
     Cmd.info "ocaml-platform" ~man ~doc ~version:"%%VERSION%%"

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -67,9 +67,8 @@ let main () =
         `Noblank;
         `P "- Editor helper: $(b,merlin)";
         `P
-          "You can install the OCaml \
-           Platform tools in your current $(b,opam) switch by running \
-           $(mname).";
+          "You can install the OCaml Platform tools in your current $(b,opam) \
+           switch by running $(mname).";
         `P
           "For more information on how to get running with OCaml, you can \
            refer to the official Get Up and Running With OCaml guide: \
@@ -89,6 +88,51 @@ let main () =
         `S Manpage.s_commands;
         `S Manpage.s_bugs;
         `P "Report them, see $(i,%%PKG_HOMEPAGE%%) for contact information.";
+        `S "NOTES";
+        `P
+          "Under the hood, $(mname) uses several mechanisms to install and \
+           cache the platform tools.";
+        `I
+          ( "The sandbox switch",
+            "The sandbox switch is a switch in which the tools will be \
+             compiled. The idea of having a separate switch is that the \
+             dependencies of the development tools should not interfere with \
+             the dependencies of your project. The platform tools are normally \
+             installed into the sandbox switch. Then, the installed files, \
+             except for the libraries, are grouped into new opam packages in \
+             the local binary repository (see below). The libraries are left \
+             out to get rid of transitive dependencies, which would defeat the \
+             goal of not interfering with the dependencies of the project." );
+        `I
+          ( "The local binary opam repository",
+            "As setting up a switch and building all platform tools there is \
+             costly in time, they are cached in a local opam repository. This \
+             also allows to install the platform tools purely through \
+             $(b,opam). The packages in this repository consists of \
+             pre-compiled packages with no libraries, so they don’t have to be \
+             built and their installation consists only of copying files. When \
+             the original package contains libraries, it differs from the \
+             binary package. In this case, the name of the binary package is \
+             suffixed with $(b,+bin+platform), and installing the original \
+             package (eg to have the library) will replace the platform one. \
+             In any case, the version of a package in the local repository \
+             contains both the original version and the ocaml version they \
+             were compiled with, as this may be important for some tools. Note \
+             that the repository is enabled by $(mname) only when it is \
+             needed, and disabled afterward, so using $(mname) should not \
+             alter the behaviour of $(b,opam)." );
+        `I
+          ( "The pipeline",
+            "When prompted to install the platform tools, for a given switch, \
+             $(mname) does the following: - First, it finds for each tool the \
+             latest version compatible with the $(b,ocaml) version of the \
+             switch - Then, it checks which tools have their version already \
+             available in the local binary repo, and which tools need to be \
+             built, - If needed, it creates the sandbox switch, to builds the \
+             tools it needs to build, and add to the local repository the new \
+             packages. - Finally, it installs all tools from the local binary \
+             repository. Note that this mechanism makes $(b,opam) fully aware \
+             of $(mname)’s installed package." );
         `S Manpage.s_authors;
         `P "Jules Aguillon, $(i,https://github.com/Julow)";
         `P "Paul-Elliot Anglès d'Auriac, $(i,https://github.com/panglesd)";

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -109,7 +109,7 @@ let main () =
              costly in time, they are cached in a local opam repository. This \
              also allows to install the platform tools purely through \
              $(b,opam). The packages in this repository consists of \
-             pre-compiled packages with no libraries, so they don’t have to be \
+             pre-compiled packages with no libraries, so they don't have to be \
              built and their installation consists only of copying files. When \
              the original package contains libraries, it differs from the \
              binary package. In this case, the name of the binary package is \
@@ -132,7 +132,7 @@ let main () =
              tools it needs to build, and add to the local repository the new \
              packages. - Finally, it installs all tools from the local binary \
              repository. Note that this mechanism makes $(b,opam) fully aware \
-             of $(mname)’s installed package." );
+             of $(mname)'s installed package." );
         `S Manpage.s_authors;
         `P "Jules Aguillon, $(i,https://github.com/Julow)";
         `P "Paul-Elliot Anglès d'Auriac, $(i,https://github.com/panglesd)";


### PR DESCRIPTION
This PR adds a `DETAILS` section to the man page, corresponding to a simplified version of the "Under the hood" README section. It is simplified as the man page format does not allow things such as heading level or item lists, which makes big explanation hard to read.

I also added a `SEE ALSO` section to redirect interested users to the repository, where there are more details.