### PR TITLE
Changelog

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,12 @@
+name: Check Changelog
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+jobs:
+  Check-Changelog:
+    name: Check Changelog Action
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: tarides/changelog-check-action@v1

--- a/.github/workflows/pr-number.yml
+++ b/.github/workflows/pr-number.yml
@@ -1,0 +1,8 @@
+name: Populate GitHub PR number in Changelog
+on: [pull_request_target]
+jobs:
+  Populate-Changelog-Action:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Update PR number
+        uses: tarides/pr-number-action@v1.1

--- a/Changes.md
+++ b/Changes.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## unreleased
+
+- Add a `DETAILS` section to the man page (#54)
+- Add guard to prevent partial script from being run (#53)
+
+## 0.0.1-alpha (2022-05-25)
+
+Initial release.


### PR DESCRIPTION
We should keep a changelog!

I propose we force ourselves to think about the changelog at every PRs. I've hooked https://github.com/tarides/changelog-check-action into the CI to check that. It'll fail if the changelog hasn't been updated, this can be disabled with the `no changelog` tag.

I've left out PRs modifying only the README (#51, #45, #49 and this one) in the initial changelog.