### PR TITLE
Distrib: Perform 'dune subst'

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,6 +65,7 @@ jobs:
         run: |
           mkdir -p release; chmod a+rw release;
           docker buildx build --platform ${{ matrix.platform.name }} --load \
+            -f src/distrib/release.Dockerfile \
             -t ocaml-platform-release-${{ matrix.platform.name }} .
           docker run --platform ${{ matrix.platform.name }} -v $PWD/release:/release \
             -e VERSION=$GITHUB_REF_NAME \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,12 +64,14 @@ jobs:
       - name: Build release tarball
         run: |
           mkdir -p release; chmod a+rw release;
+          docker buildx build --platform ${{ matrix.platform.name }} --load \
+            -t ocaml-platform-release-${{ matrix.platform.name }} .
           docker run --platform ${{ matrix.platform.name }} -v $PWD/release:/release \
             -e VERSION=$GITHUB_REF_NAME \
             -e TARGETOS=linux \
             -e TARGETARCH=${{ matrix.platform.target_arch }} \
             -e OUTPUT=/release \
-            ocaml-platform-build-${{ matrix.platform.name }} \
+            ocaml-platform-release-${{ matrix.platform.name }} \
             opam exec -- bash src/distrib/release.sh
 
       - name: upload archives

--- a/src/distrib/release.Dockerfile
+++ b/src/distrib/release.Dockerfile
@@ -1,0 +1,7 @@
+FROM ocaml/opam:alpine-ocaml-4.14
+WORKDIR ocaml-platform/
+
+COPY --chown=opam *.opam .
+RUN opam install -y --deps-only --with-test --with-doc .
+
+COPY --chown=opam . .

--- a/src/distrib/release.Dockerfile.dockerignore
+++ b/src/distrib/release.Dockerfile.dockerignore
@@ -1,0 +1,1 @@
+# Override the top-level .dockerignore

--- a/src/distrib/release.sh
+++ b/src/distrib/release.sh
@@ -3,6 +3,8 @@ set -xeuo pipefail
 
 archive_name=$OUTPUT/ocaml-platform-$VERSION-$TARGETOS-$TARGETARCH.tar
 
+dune subst
+
 dune build -p platform
 # Executables are symlinks, follow with -h.
 tar hcf "$archive_name" -C _build/install/default bin/ocaml-platform


### PR DESCRIPTION
Almost close https://github.com/tarides/ocaml-platform/issues/55 (`--version` and `--help` are fixed, the release notes remain)

A new dockerfile is needed because the image previously used for building the release didn't copy the entire repository (to speed up the tests).